### PR TITLE
서비스로직,컨트롤러 테스트 완료 및 코드 리펙토링

### DIFF
--- a/src/main/java/com/Hanium/CarCamping/Exception/CannotRecommendMyReviewException.java
+++ b/src/main/java/com/Hanium/CarCamping/Exception/CannotRecommendMyReviewException.java
@@ -1,0 +1,11 @@
+package com.Hanium.CarCamping.Exception;
+
+public class CannotRecommendMyReviewException extends RuntimeException {
+    public CannotRecommendMyReviewException() {
+        super();
+    }
+
+    public CannotRecommendMyReviewException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/Hanium/CarCamping/Exception/DuplicateCampSiteException.java
+++ b/src/main/java/com/Hanium/CarCamping/Exception/DuplicateCampSiteException.java
@@ -1,0 +1,11 @@
+package com.Hanium.CarCamping.Exception;
+
+public class DuplicateCampSiteException extends RuntimeException {
+    public DuplicateCampSiteException() {
+        super();
+    }
+
+    public DuplicateCampSiteException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/Hanium/CarCamping/Exception/NoSuchReviewException.java
+++ b/src/main/java/com/Hanium/CarCamping/Exception/NoSuchReviewException.java
@@ -1,0 +1,11 @@
+package com.Hanium.CarCamping.Exception;
+
+public class NoSuchReviewException extends RuntimeException {
+    public NoSuchReviewException() {
+        super();
+    }
+
+    public NoSuchReviewException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/Hanium/CarCamping/Exception/NotCampSiteRegisterException.java
+++ b/src/main/java/com/Hanium/CarCamping/Exception/NotCampSiteRegisterException.java
@@ -1,0 +1,11 @@
+package com.Hanium.CarCamping.Exception;
+
+public class NotCampSiteRegisterException extends RuntimeException {
+    public NotCampSiteRegisterException() {
+        super();
+    }
+
+    public NotCampSiteRegisterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/Hanium/CarCamping/Exception/NotReviewWriterException.java
+++ b/src/main/java/com/Hanium/CarCamping/Exception/NotReviewWriterException.java
@@ -1,0 +1,11 @@
+package com.Hanium.CarCamping.Exception;
+
+public class NotReviewWriterException extends RuntimeException{
+    public NotReviewWriterException() {
+        super();
+    }
+
+    public NotReviewWriterException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/Hanium/CarCamping/Exception/advice/CustomExceptionHandler.java
+++ b/src/main/java/com/Hanium/CarCamping/Exception/advice/CustomExceptionHandler.java
@@ -1,0 +1,70 @@
+package com.Hanium.CarCamping.Exception.advice;
+
+import com.Hanium.CarCamping.Exception.*;
+import com.Hanium.CarCamping.domain.dto.response.Result;
+import com.Hanium.CarCamping.service.Reponse.ResponseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RequiredArgsConstructor
+@RestControllerAdvice
+public class CustomExceptionHandler {
+    private final ResponseService responseService;
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result defaultException(HttpServletRequest request, Exception e) {
+        e.printStackTrace();
+        return responseService.getFailResult(-1000, "오류가 발생하였습니다.");
+    }
+
+    @ExceptionHandler(NoSuchMemberException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result NoSuchMemberException() {
+        return responseService.getFailResult(-1001, "존재하지 않는 회원입니다.");
+    }
+
+    @ExceptionHandler(NoSuchReviewException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result NoSuchReviewException() {
+        return responseService.getFailResult(-1002, "존재하지 않는 리뷰입니다.");
+    }
+
+    @ExceptionHandler(NoSuchCampSiteException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result NoSuchCampSiteException() {
+        return responseService.getFailResult(-1003, "존재하지 않는 차박지입니다.");
+    }
+    @ExceptionHandler(DuplicateCampSiteException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result DuplicateCampSiteException() {
+        return responseService.getFailResult(-1004, "이미 존재하는 차박지입니다.");
+    }
+    @ExceptionHandler(NotCampSiteRegisterException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result NotCampSiteRegisterException() {
+        return responseService.getFailResult(-1005, "차박지 등록자가 아닙니다.");
+    }
+    @ExceptionHandler(NotReviewWriterException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result NotReviewWriterException() {
+        return responseService.getFailResult(-1006, "리뷰 등록자가 아닙니다.");
+    }
+    @ExceptionHandler(CannotRecommendMyReviewException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result CannotRecommendMyReviewException() {
+        return responseService.getFailResult(-1007, "내 리뷰는 평가할 수 없습니다.");
+    }
+    @ExceptionHandler(AlreadyParticipateException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public Result AlreadyParticipateException() {
+        return responseService.getFailResult(-1008, "이미 평가한 리뷰입니다.");
+    }
+
+
+}

--- a/src/main/java/com/Hanium/CarCamping/controller/Review_Member/Review_MemberController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/Review_Member/Review_MemberController.java
@@ -1,8 +1,10 @@
 package com.Hanium.CarCamping.controller.Review_Member;
 
 import com.Hanium.CarCamping.config.security.jwt.JwtService;
+import com.Hanium.CarCamping.domain.dto.response.Result;
 import com.Hanium.CarCamping.domain.entity.Review;
 import com.Hanium.CarCamping.domain.entity.member.Member;
+import com.Hanium.CarCamping.service.Reponse.ResponseService;
 import com.Hanium.CarCamping.service.Review.ReviewService;
 import com.Hanium.CarCamping.service.Review_Member.ReviewMemberService;
 import lombok.RequiredArgsConstructor;
@@ -15,18 +17,19 @@ public class Review_MemberController {
     private final ReviewMemberService reviewMemberService;
     private final ReviewService reviewService;
     private final JwtService jwtService;
+    private final ResponseService responseService;
 
     @GetMapping("/review/{id}/up")
-    public void upReview(@RequestParam("token") String token, @PathVariable Long id) {
-        Review review = reviewService.getReview(id);
+    public Result upReview(@RequestParam("token") String token, @PathVariable Long id) {
         Member member = jwtService.findMemberByToken(token);
-        reviewMemberService.createReviewMember(review,member,1);
+        reviewMemberService.createReviewMember(id,member.getId(),1);
+        return responseService.getSuccessResult();
     }
     @GetMapping("/review/{id}/down")
-    public void downReview(@RequestParam("token") String token, @PathVariable Long id) {
-        Review review = reviewService.getReview(id);
+    public Result downReview(@RequestParam("token") String token, @PathVariable Long id) {
         Member member = jwtService.findMemberByToken(token);
-        reviewMemberService.createReviewMember(review,member,-1);
+        reviewMemberService.createReviewMember(id,member.getId(),-1);
+        return responseService.getSuccessResult();
     }
 
 }

--- a/src/main/java/com/Hanium/CarCamping/controller/campSite/CampSiteController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/campSite/CampSiteController.java
@@ -40,7 +40,8 @@ public class CampSiteController {
     @GetMapping("/camping/{location}/grade")
     public Result getLocationCampSiteListByGrade(@RequestParam("token") String token,@PathVariable Region location) {
         jwtService.isUsable(token);
-        List<CampSite> byRegion = campsiteService.findByRegion(location);
+        List<CampSite> byRegion = campsiteService.getCampSiteByRegionAndScoreDESC(location);
         return responseService.getListResult(byRegion.stream().map(ResponseCampSiteListDto::convertResponseCampSiteDto).collect(Collectors.toList()));
     }
+
 }

--- a/src/main/java/com/Hanium/CarCamping/controller/campSite/CampSiteController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/campSite/CampSiteController.java
@@ -27,21 +27,42 @@ public class CampSiteController {
     @PostMapping("/camping/register")
     public Result registerCampSite(@RequestParam("token") String token, @RequestBody CreateCampSiteDto createCampSiteDto) {
         Member memberByToken = jwtService.findMemberByToken(token);
-        campsiteService.saveCampSite(createCampSiteDto,memberByToken);
+        campsiteService.saveCampSite(createCampSiteDto, memberByToken);
         return responseService.getSuccessResult();
     }
 
-    @PostMapping("/camping")
-    public Result getByName(@RequestParam("token") String token,@RequestBody String name) {
+    @GetMapping("/camping")
+    public Result getByName(@RequestParam("token") String token, @RequestParam String name) {
         jwtService.isUsable(token);
         return responseService.getSingleResult(ResponseCampSiteDto.convertCampSiteDto(campsiteService.findByName(name)));
     }
 
     @GetMapping("/camping/{location}/grade")
-    public Result getLocationCampSiteListByGrade(@RequestParam("token") String token,@PathVariable Region location) {
+    public Result getLocationCampSiteListByGrade(@RequestParam("token") String token, @PathVariable String location) {
         jwtService.isUsable(token);
-        List<CampSite> byRegion = campsiteService.getCampSiteByRegionAndScoreDESC(location);
+        List<CampSite> byRegion = campsiteService.getCampSiteByRegionAndScoreDESC(Region.valueOf(location));
         return responseService.getListResult(byRegion.stream().map(ResponseCampSiteListDto::convertResponseCampSiteDto).collect(Collectors.toList()));
     }
 
+    @GetMapping("/camping/{campsite_id}")
+    public Result getSingleCampSite(@RequestParam("token") String token, @PathVariable Long campsite_id) {
+        jwtService.isUsable(token);
+        CampSite result = campsiteService.findById(campsite_id);
+        return responseService.getSingleResult(ResponseCampSiteDto.convertCampSiteDto(result));
+    }
+
+    @DeleteMapping("/camping/delete/{campsite_id}")
+    public Result deleteCampSite(@RequestParam("token") String token, @PathVariable Long campsite_id) {
+        jwtService.isUsable(token);
+        Member memberByToken = jwtService.findMemberByToken(token);
+        campsiteService.deleteCampSite(memberByToken, campsite_id);
+        return responseService.getSuccessResult();
+    }
+
+    @GetMapping("camping/all")
+    public Result allCampSite(@RequestParam("token") String token) {
+        jwtService.isUsable(token);
+        List<CampSite> allCampSiteList = campsiteService.getAllCampSiteList();
+        return responseService.getListResult(allCampSiteList.stream().map(ResponseCampSiteListDto::convertResponseCampSiteDto).collect(Collectors.toList()));
+    }
 }

--- a/src/main/java/com/Hanium/CarCamping/controller/member/memberController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/member/memberController.java
@@ -19,6 +19,7 @@ import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class memberController {
 
     private final MemberSignInService memberSignInService;

--- a/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
@@ -75,4 +75,10 @@ public class reviewController {
         reviewService.deleteReview(jwtService.findEmailByJwt(token),review_id);
         return responseService.getSuccessResult();
     }
+    @GetMapping
+    public Result getMostRecommend3Review(@RequestParam("token") String token, @PathVariable Long camping_id) {
+        jwtService.isUsable(token);
+        List<Review> result = reviewService.mostRecommendedTop3Review(camping_id);
+        return responseService.getListResult(result.stream().map(ResponseReviewDto::convertToReviewDto).collect(Collectors.toList()));
+    }
 }

--- a/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
@@ -68,4 +68,11 @@ public class reviewController {
         jwtService.isUsable(token);
         return responseService.getSingleResult(ResponseReviewDto.convertToReviewDto(reviewService.getReview(review_id)));
     }
+
+    @DeleteMapping("campingReview/{review_id}")
+    public Result deleteReview(@RequestParam("token") String token, @PathVariable Long review_id) {
+        jwtService.isUsable(token);
+        reviewService.deleteReview(jwtService.findEmailByJwt(token),review_id);
+        return responseService.getSuccessResult();
+    }
 }

--- a/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
@@ -38,7 +38,6 @@ public class reviewController {
     public Result getReviewListByGrade(@RequestParam("token") String token, @PathVariable Long camping_id) {
         jwtService.isUsable(token);
         List<Review> result= reviewService.getCampSiteReviewByScoreDESC(camping_id);
-        System.out.println(result.get(0).getWriter().getId());
         return responseService.getListResult(result.stream().map(ResponseReviewDto::convertToReviewDto).collect(Collectors.toList()));
     }
 
@@ -66,7 +65,7 @@ public class reviewController {
     @GetMapping("/campingReview/{review_id}")
     public Result getReview(@RequestParam("token") String token, @PathVariable Long review_id) {
         jwtService.isUsable(token);
-        return responseService.getSingleResult(ResponseReviewDto.convertToReviewDto(reviewService.getReview(review_id)));
+        return responseService.getSingleResult(reviewService.getReviewByDto(review_id));
     }
 
     @DeleteMapping("campingReview/{review_id}")
@@ -75,7 +74,7 @@ public class reviewController {
         reviewService.deleteReview(jwtService.findEmailByJwt(token),review_id);
         return responseService.getSuccessResult();
     }
-    @GetMapping
+    @GetMapping("campingReview/{camping_id}/most")
     public Result getMostRecommend3Review(@RequestParam("token") String token, @PathVariable Long camping_id) {
         jwtService.isUsable(token);
         List<Review> result = reviewService.mostRecommendedTop3Review(camping_id);

--- a/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
+++ b/src/main/java/com/Hanium/CarCamping/controller/review/reviewController.java
@@ -26,19 +26,19 @@ public class reviewController {
     private final ResponseService responseService;
 
     @PostMapping("/review/{camping_id}")
-    public Result registerReview(CreateReviewDto createReviewDto,
+    public Result registerReview(@RequestBody CreateReviewDto createReviewDto,
                                  @RequestParam("token") String token,
                                  @PathVariable Long camping_id) {
-        Member member = jwtService.findMemberByToken(token);
-        CampSite campsite = campsiteService.findById(camping_id);
-        reviewService.saveReview(createReviewDto, member, campsite);
+        Member memberByToken = jwtService.findMemberByToken(token);
+        reviewService.saveReview(createReviewDto, memberByToken.getId(), camping_id);
         return responseService.getSuccessResult();
     }
 
     @GetMapping("/campingReview/{camping_id}/gradeUp")
     public Result getReviewListByGrade(@RequestParam("token") String token, @PathVariable Long camping_id) {
         jwtService.isUsable(token);
-        List<Review> result = reviewService.getCampSiteReviewByScoreDESC(camping_id);
+        List<Review> result= reviewService.getCampSiteReviewByScoreDESC(camping_id);
+        System.out.println(result.get(0).getWriter().getId());
         return responseService.getListResult(result.stream().map(ResponseReviewDto::convertToReviewDto).collect(Collectors.toList()));
     }
 

--- a/src/main/java/com/Hanium/CarCamping/domain/dto/campsite/CreateCampSiteDto.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/dto/campsite/CreateCampSiteDto.java
@@ -1,12 +1,16 @@
 package com.Hanium.CarCamping.domain.dto.campsite;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class CreateCampSiteDto {
     @NotBlank
     private String name;

--- a/src/main/java/com/Hanium/CarCamping/domain/dto/campsite/ResponseCampSiteDto.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/dto/campsite/ResponseCampSiteDto.java
@@ -17,6 +17,9 @@ public class ResponseCampSiteDto {
     private String address;
     private String image;
     private Float score;
+    private String explanation;
+    private String videoLink;
+
 
     public static ResponseCampSiteDto convertCampSiteDto(CampSite campSite) {
         return ResponseCampSiteDto.builder()
@@ -24,6 +27,8 @@ public class ResponseCampSiteDto {
                 .name(campSite.getName())
                 .address(campSite.getAddress())
                 .image(campSite.getImage())
-                .score(campSite.getScore()).build();
+                .score(campSite.getScore())
+                .explanation(campSite.getExplanation())
+                .videoLink(campSite.getVideoLink()).build();
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/domain/dto/member/signInDto.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/dto/member/signInDto.java
@@ -1,9 +1,12 @@
 package com.Hanium.CarCamping.domain.dto.member;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class signInDto {
     private String email;
     private String password;

--- a/src/main/java/com/Hanium/CarCamping/domain/dto/review/ResponseReviewDto.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/dto/review/ResponseReviewDto.java
@@ -14,6 +14,7 @@ public class ResponseReviewDto {
     private String title;
     private Float Score;
     private LocalDateTime date;
+    private Integer recommend;
 
     public static ResponseReviewDto convertToReviewDto(Review review) {
         return ResponseReviewDto.builder()
@@ -21,6 +22,8 @@ public class ResponseReviewDto {
                 .writer(review.getWriter().getNickname())
                 .title(review.getTitle())
                 .Score(review.getScore())
-                .date(review.getDate()).build();
+                .date(review.getDate())
+                .recommend(review.getRecommend())
+                .build();
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
@@ -32,8 +32,9 @@ public class CampSite {
     private List<Review> reviewList = new ArrayList<>();
 
     @Column(nullable = false)
-    private Float score;
-
+    private float score;
+    private float scoreSum;
+    private float reviewNum;
 
     @ManyToOne
     @JoinColumn(name = "registrant_id")
@@ -62,5 +63,15 @@ public class CampSite {
         campSite.registrant=member;
         return campSite;
 
+    }
+
+    public void changeScore(float reviewScore,int i) {
+        this.scoreSum+=reviewScore;
+        this.reviewNum+=i;
+        if (reviewNum == 0) {
+            this.score = 0f;
+        } else {
+            this.score=this.scoreSum/this.reviewNum;
+        }
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
@@ -27,7 +27,7 @@ public class CampSite {
     private String address;
 
 
-    @OneToMany(mappedBy = "campSite", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "campSite",orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
@@ -28,7 +28,7 @@ public class CampSite {
 
 
 
-    @OneToMany(mappedBy = "campSite")
+    @OneToMany(mappedBy = "campSite",orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/CampSite.java
@@ -27,7 +27,8 @@ public class CampSite {
     private String address;
 
 
-    @OneToMany(mappedBy = "campSite",orphanRemoval = true)
+
+    @OneToMany(mappedBy = "campSite")
     private List<Review> reviewList = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Point.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Point.java
@@ -1,0 +1,30 @@
+package com.Hanium.CarCamping.domain.entity;
+
+import com.Hanium.CarCamping.domain.entity.member.Member;
+import lombok.Data;
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+public class Point {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "point_id")
+    private Long id;
+    private String contents;
+    private int score;
+    private LocalDateTime datetime;
+    @ManyToOne
+    @JoinColumn(name="member_id")
+    private Member owner;
+
+    static public Point createPoint(Member member,String contents,int score) {
+        Point point=new Point();
+        point.contents=contents;
+        point.datetime=LocalDateTime.now();
+        point.score=score;
+        point.owner=member;
+        return point;
+    }
+
+}

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Point.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Point.java
@@ -14,7 +14,7 @@ public class Point {
     private String contents;
     private int score;
     private LocalDateTime datetime;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="member_id")
     private Member owner;
 

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Review.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Review.java
@@ -39,7 +39,7 @@ public class Review {
     @JoinColumn(name="campsite_id")
     private CampSite campSite;
 
-    @OneToMany(mappedBy = "review_id",cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "review_id",cascade = CascadeType.ALL,orphanRemoval = true)
     private Set<Review_Member> participants = new HashSet<>();
 
     private Integer recommend;

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Review.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Review.java
@@ -85,4 +85,5 @@ public class Review {
 
     }
 
-}
+
+

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Review_Member.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Review_Member.java
@@ -25,8 +25,8 @@ public class Review_Member {
 
     public static Review_Member createReview_Member(Review review, Member member,int i) {
         Review_Member review_member = new Review_Member();
-        review_member.setReview_id(review);
         review_member.member_id=member;
+        review_member.setReview_id(review);
         review.changeRecommend(i);
         return review_member;
     }

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Review_Member.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Review_Member.java
@@ -44,4 +44,12 @@ public class Review_Member {
             return false;
         }
     }
+
+    @Override
+    public int hashCode() {
+        final int PRIME=31;
+        int result=1;
+        result= (int) (review_id.getReview_id()+member_id.getId());
+        return result;
+    }
 }

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/Review_Member.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/Review_Member.java
@@ -33,7 +33,15 @@ public class Review_Member {
 
     public void setReview_id(Review review) {
         this.review_id=review;
-        review.getParticipants().add(this);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        Review_Member m=(Review_Member)o;
+        if (this.member_id.getId().equals(m.member_id.getId()) && this.review_id.getReview_id().equals(m.review_id.getReview_id())) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/member/Member.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/member/Member.java
@@ -1,5 +1,6 @@
 package com.Hanium.CarCamping.domain.entity.member;
 
+import com.Hanium.CarCamping.domain.entity.Point;
 import com.Hanium.CarCamping.domain.entity.Review;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,6 +39,8 @@ public class Member {
 
     @OneToMany(mappedBy = "writer")
     private List<Review> reviewList = new ArrayList<>();
+    @OneToMany(mappedBy="owner")
+    private List<Point> pointList=new ArrayList<>();
 
     @Builder
     public Member(final String email,

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/member/Member.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/member/Member.java
@@ -36,7 +36,7 @@ public class Member {
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
-    @OneToMany(mappedBy = "writer",orphanRemoval = true)
+    @OneToMany(mappedBy = "writer")
     private List<Review> reviewList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/Hanium/CarCamping/domain/entity/member/Member.java
+++ b/src/main/java/com/Hanium/CarCamping/domain/entity/member/Member.java
@@ -36,7 +36,7 @@ public class Member {
     @Enumerated(value = EnumType.STRING)
     private Role role;
 
-    @OneToMany(mappedBy = "writer", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "writer",orphanRemoval = true)
     private List<Review> reviewList = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/Hanium/CarCamping/repository/CampSiteRepository.java
+++ b/src/main/java/com/Hanium/CarCamping/repository/CampSiteRepository.java
@@ -19,5 +19,8 @@ public interface CampSiteRepository extends JpaRepository<CampSite,Long> {
 
     Optional<CampSite> findByName(String name);
 
+    List<CampSite> findAllByOrderByScoreDesc();
+    List<CampSite> findByRegionOrderByScoreDesc(Region region);
+    List<CampSite> findByRegionOrderByScoreAsc(Region region);
 
 }

--- a/src/main/java/com/Hanium/CarCamping/repository/PointRepository.java
+++ b/src/main/java/com/Hanium/CarCamping/repository/PointRepository.java
@@ -1,0 +1,7 @@
+package com.Hanium.CarCamping.repository;
+
+import com.Hanium.CarCamping.domain.entity.Point;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PointRepository extends JpaRepository<Point,Long> {
+}

--- a/src/main/java/com/Hanium/CarCamping/repository/ReviewMemberRepository.java
+++ b/src/main/java/com/Hanium/CarCamping/repository/ReviewMemberRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 
+
 public interface
 ReviewMemberRepository extends JpaRepository<Review_Member, Long> {
     @Query("select t from Review_Member t join fetch t.member_id m join fetch t.review_id r where t.review_id.review_id=:review and t.member_id.id=:member")

--- a/src/main/java/com/Hanium/CarCamping/repository/ReviewRepository.java
+++ b/src/main/java/com/Hanium/CarCamping/repository/ReviewRepository.java
@@ -11,20 +11,20 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review,Long> {
 
 
-    @Query("select r from Review r where r.campSite.campsite_id=:campsite_id order by r.date DESC")
+    @Query("select r from Review r join fetch r.writer m where r.campSite.campsite_id=:campsite_id order by r.date DESC")
     List<Review> findByCampSiteDateDESC(@Param("campsite_id")Long campSite_id);
 
-    @Query("select r from Review r where r.campSite.campsite_id=:campsite_id order by r.date ASC")
+    @Query("select r from Review r join fetch r.writer m where r.campSite.campsite_id=:campsite_id order by r.date ASC")
     List<Review> findByCampSiteDateASC(@Param("campsite_id")Long campSite_id);
 
 
-    @Query("select r from Review r where r.campSite.campsite_id=:campsite_id order by r.score DESC")
+    @Query("select r from Review r join fetch r.writer m where r.campSite.campsite_id=:campsite_id order by r.score DESC")
     List<Review> findByCampSiteDESC(@Param("campsite_id")Long campSite_id);
 
-    @Query("select r from Review r where r.campSite.campsite_id=:campsite_id order by r.score ASC")
+    @Query("select r from Review r join fetch r.writer m where r.campSite.campsite_id=:campsite_id order by r.score ASC")
     List<Review> findByCampSiteASC(@Param("campsite_id")Long campSite_id);
 
-    @Query("select r from Review r where r.campSite.campsite_id=:campsite_id")
+    @Query("select r from Review r join fetch r.writer m where r.campSite.campsite_id=:campsite_id")
     List<Review> findReviewByCampSite(@Param("campsite_id")Long campSite_id);
 
     List<Review> findTop3ByCampSiteOrderByRecommendDesc(CampSite campSite);

--- a/src/main/java/com/Hanium/CarCamping/repository/ReviewRepository.java
+++ b/src/main/java/com/Hanium/CarCamping/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
 package com.Hanium.CarCamping.repository;
 
+import com.Hanium.CarCamping.domain.entity.CampSite;
 import com.Hanium.CarCamping.domain.entity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +27,5 @@ public interface ReviewRepository extends JpaRepository<Review,Long> {
     @Query("select r from Review r where r.campSite.campsite_id=:campsite_id")
     List<Review> findReviewByCampSite(@Param("campsite_id")Long campSite_id);
 
+    List<Review> findTop3ByCampSiteOrderByRecommendDesc(CampSite campSite);
 }

--- a/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
@@ -8,6 +8,7 @@ import com.Hanium.CarCamping.domain.dto.campsite.CreateCampSiteDto;
 import com.Hanium.CarCamping.domain.entity.CampSite;
 import com.Hanium.CarCamping.domain.entity.member.Member;
 import com.Hanium.CarCamping.repository.CampSiteRepository;
+import com.Hanium.CarCamping.service.Point.PointService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,7 +21,7 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class CampsiteService {
     private final CampSiteRepository campSiteRepository;
-
+    private final PointService pointService;
     @Transactional
     public Long saveCampSite(CreateCampSiteDto createCampSiteDto, Member member) {
         Optional<CampSite> byName = campSiteRepository.findByName(createCampSiteDto.getName());
@@ -30,6 +31,7 @@ public class CampsiteService {
             }
         }
         CampSite save = campSiteRepository.save(CampSite.createCampSite(createCampSiteDto, member));
+        pointService.create(member,"차박지 등록",100);
         return save.getCampsite_id();
     }
 
@@ -56,5 +58,16 @@ public class CampsiteService {
         } else {
             campSiteRepository.delete(campSite);
         }
+    }
+
+    public List<CampSite> getCampSiteByScore() {
+        return campSiteRepository.findAllByOrderByScoreDesc();
+    }
+
+    public List<CampSite> getCampSiteByRegionAndScoreDESC(Region region) {
+        return campSiteRepository.findByRegionOrderByScoreDesc(region);
+    }
+    public List<CampSite> getCampSiteByRegionAndScoreASC(Region region) {
+        return campSiteRepository.findByRegionOrderByScoreAsc(region);
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
@@ -2,6 +2,7 @@ package com.Hanium.CarCamping.service.CampSite;
 
 import com.Hanium.CarCamping.Exception.DuplicateCampSiteException;
 import com.Hanium.CarCamping.Exception.NoSuchCampSiteException;
+import com.Hanium.CarCamping.Exception.NotCampSiteRegisterException;
 import com.Hanium.CarCamping.domain.Region;
 import com.Hanium.CarCamping.domain.dto.campsite.CreateCampSiteDto;
 import com.Hanium.CarCamping.domain.entity.CampSite;
@@ -46,5 +47,14 @@ public class CampsiteService {
     public List<CampSite> getAllCampSiteList() {
         return
                 campSiteRepository.findAll();
+    }
+    @Transactional
+    public void deleteCampSite(Long member_id,Long campSite_id) {
+        CampSite campSite = campSiteRepository.findById(campSite_id).orElseThrow(NoSuchCampSiteException::new);
+        if (!campSite.getRegistrant().getId().equals(member_id)) {
+            throw new NotCampSiteRegisterException("차박지 등록자가 아닙니다");
+        } else {
+            campSiteRepository.delete(campSite);
+        }
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
@@ -1,5 +1,6 @@
 package com.Hanium.CarCamping.service.CampSite;
 
+import com.Hanium.CarCamping.Exception.DuplicateCampSiteException;
 import com.Hanium.CarCamping.Exception.NoSuchCampSiteException;
 import com.Hanium.CarCamping.domain.Region;
 import com.Hanium.CarCamping.domain.dto.campsite.CreateCampSiteDto;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +22,12 @@ public class CampsiteService {
 
     @Transactional
     public Long saveCampSite(CreateCampSiteDto createCampSiteDto, Member member) {
+        Optional<CampSite> byName = campSiteRepository.findByName(createCampSiteDto.getName());
+        if (byName.isPresent()) {
+            if (byName.get().getRegion().toString().equals(createCampSiteDto.getRegion())) {
+                throw new DuplicateCampSiteException("이미 등록되어있는 차박지입니다");
+            }
+        }
         CampSite save = campSiteRepository.save(CampSite.createCampSite(createCampSiteDto, member));
         return save.getCampsite_id();
     }

--- a/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/CampSite/CampsiteService.java
@@ -36,7 +36,7 @@ public class CampsiteService {
     }
 
     public CampSite findById(Long id) {
-        return campSiteRepository.getById(id);
+        return campSiteRepository.findById(id).orElseThrow(NoSuchCampSiteException::new);
     }
     public List<CampSite> findByRegion(Region region) {
         System.out.println(region.name());
@@ -44,6 +44,8 @@ public class CampsiteService {
     }
 
     public CampSite findByName(String name) {
+        System.out.println("hi");
+        System.out.println(name);
         return campSiteRepository.findByName(name).orElseThrow(NoSuchCampSiteException::new);
     }
     public List<CampSite> getAllCampSiteList() {
@@ -51,11 +53,12 @@ public class CampsiteService {
                 campSiteRepository.findAll();
     }
     @Transactional
-    public void deleteCampSite(Long member_id,Long campSite_id) {
+    public void deleteCampSite(Member member,Long campSite_id) {
         CampSite campSite = campSiteRepository.findById(campSite_id).orElseThrow(NoSuchCampSiteException::new);
-        if (!campSite.getRegistrant().getId().equals(member_id)) {
+        if (!campSite.getRegistrant().getId().equals(member.getId())) {
             throw new NotCampSiteRegisterException("차박지 등록자가 아닙니다");
         } else {
+            pointService.create(member,"차박지 삭제",-100);
             campSiteRepository.delete(campSite);
         }
     }

--- a/src/main/java/com/Hanium/CarCamping/service/Point/PointService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Point/PointService.java
@@ -1,0 +1,22 @@
+package com.Hanium.CarCamping.service.Point;
+
+import com.Hanium.CarCamping.domain.entity.Point;
+import com.Hanium.CarCamping.domain.entity.member.Member;
+import com.Hanium.CarCamping.repository.PointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PointService {
+    private final PointRepository pointRepository;
+
+    @Transactional
+    public void create(Member member,String content, int score) {
+        Point point = Point.createPoint(member, content, score);
+        member.setPoint(member.getPoint()+score);
+        pointRepository.save(point);
+    }
+}

--- a/src/main/java/com/Hanium/CarCamping/service/Review/ReviewService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review/ReviewService.java
@@ -6,6 +6,7 @@ import com.Hanium.CarCamping.Exception.NoSuchReviewException;
 import com.Hanium.CarCamping.Exception.NotReviewWriterException;
 import com.Hanium.CarCamping.config.security.jwt.JwtService;
 import com.Hanium.CarCamping.domain.dto.review.CreateReviewDto;
+import com.Hanium.CarCamping.domain.dto.review.ResponseReviewDto;
 import com.Hanium.CarCamping.domain.entity.CampSite;
 import com.Hanium.CarCamping.domain.entity.Review;
 import com.Hanium.CarCamping.domain.entity.member.Member;
@@ -52,8 +53,13 @@ public class ReviewService {
     }
 
     public Review getReview(Long id) {
-        return reviewRepository.getById(id);
+        return reviewRepository.findById(id).orElseThrow(NoSuchMemberException::new);
     }
+    public ResponseReviewDto getReviewByDto(Long id) {
+        Review review = reviewRepository.findById(id).orElseThrow(NoSuchMemberException::new);
+        return ResponseReviewDto.convertToReviewDto(review);
+    }
+
 
     public List<Review> getAllReview() {
         return reviewRepository.findAll();

--- a/src/main/java/com/Hanium/CarCamping/service/Review/ReviewService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review/ReviewService.java
@@ -58,6 +58,9 @@ public class ReviewService {
         if (!result.getId().equals(review.getWriter().getId())) {
             throw new NotReviewWriterException("리뷰 작성자가 아닙니다");
         }
-        reviewRepository.deleteAll();
+        reviewRepository.delete(review);
+    }
+    public List<Review> mostRecommendedTop3Review(CampSite campsite) {
+        return reviewRepository.findTop3ByCampSiteOrderByRecommendDesc(campsite);
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/service/Review/ReviewService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review/ReviewService.java
@@ -1,21 +1,27 @@
 package com.Hanium.CarCamping.service.Review;
 
+import com.Hanium.CarCamping.Exception.NoSuchMemberException;
+import com.Hanium.CarCamping.Exception.NoSuchReviewException;
+import com.Hanium.CarCamping.Exception.NotReviewWriterException;
 import com.Hanium.CarCamping.domain.dto.review.CreateReviewDto;
 import com.Hanium.CarCamping.domain.entity.CampSite;
 import com.Hanium.CarCamping.domain.entity.Review;
 import com.Hanium.CarCamping.domain.entity.member.Member;
+import com.Hanium.CarCamping.repository.MemberRepository;
 import com.Hanium.CarCamping.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ReviewService {
     private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
     @Transactional
     public Long saveReview(CreateReviewDto createReviewDto, Member writer, CampSite campSite) {
         Review save = reviewRepository.save(Review.createReview(createReviewDto, writer, campSite));
@@ -44,5 +50,14 @@ public class ReviewService {
     }
     public List<Review> findByCampSite(Long campsite_id){
         return reviewRepository.findReviewByCampSite(campsite_id);
+    }
+    @Transactional
+    public void deleteReview(String email,Long review_id) {
+        Review review= reviewRepository.findById(review_id).orElseThrow(NoSuchReviewException::new);
+        Member result= memberRepository.findByEmail(email).orElseThrow(NoSuchMemberException::new);
+        if (!result.getId().equals(review.getWriter().getId())) {
+            throw new NotReviewWriterException("리뷰 작성자가 아닙니다");
+        }
+        reviewRepository.deleteAll();
     }
 }

--- a/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
@@ -39,15 +39,15 @@ public void createReviewMember(Review review, Member member, int i) {
 
     public Long create(Review review, Member member, int i) {
         Review_Member review_member = Review_Member.createReview_Member(review, member, i);
-        System.out.println(review.getParticipants().contains(review_member));
+
         if (review.getWriter().getId().equals(member.getId())) {
             throw new CannotRecommendMyReviewException("자신의 리뷰는 추천할 수 없습니다");
         }
         if (review.getParticipants().contains(review_member)) {
             throw new AlreadyParticipateException("이미 평가한 리뷰입니다");
         }
-        review.getParticipants().add(review_member);
         Review_Member save = reviewMemberRepository.save(review_member);
+        review.getParticipants().add(save);
         return save.getReview_member_id();
 
     }

--- a/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
@@ -6,6 +6,7 @@ import com.Hanium.CarCamping.domain.entity.Review;
 import com.Hanium.CarCamping.domain.entity.Review_Member;
 import com.Hanium.CarCamping.domain.entity.member.Member;
 import com.Hanium.CarCamping.repository.ReviewMemberRepository;
+import com.Hanium.CarCamping.service.Point.PointService;
 import com.Hanium.CarCamping.service.Review.ReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,7 +18,7 @@ import java.util.List;
 @Transactional
 @RequiredArgsConstructor
 public class ReviewMemberService {
-    private final ReviewService reviewService;
+    private final PointService pointService;
     private final ReviewMemberRepository reviewMemberRepository;
 
 
@@ -34,6 +35,7 @@ public Long createReviewMember(Review review, Member member, int i) {
 
     Review_Member save = reviewMemberRepository.save(review_member);
     review.getParticipants().add(save);
+    pointService.create(member,"리뷰 평가 참여",2);
     return save.getReview_member_id();
 
 }

--- a/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
@@ -2,10 +2,14 @@ package com.Hanium.CarCamping.service.Review_Member;
 
 import com.Hanium.CarCamping.Exception.AlreadyParticipateException;
 import com.Hanium.CarCamping.Exception.CannotRecommendMyReviewException;
+import com.Hanium.CarCamping.Exception.NoSuchMemberException;
+import com.Hanium.CarCamping.Exception.NoSuchReviewException;
 import com.Hanium.CarCamping.domain.entity.Review;
 import com.Hanium.CarCamping.domain.entity.Review_Member;
 import com.Hanium.CarCamping.domain.entity.member.Member;
+import com.Hanium.CarCamping.repository.MemberRepository;
 import com.Hanium.CarCamping.repository.ReviewMemberRepository;
+import com.Hanium.CarCamping.repository.ReviewRepository;
 import com.Hanium.CarCamping.service.Point.PointService;
 import com.Hanium.CarCamping.service.Review.ReviewService;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +24,13 @@ import java.util.List;
 public class ReviewMemberService {
     private final PointService pointService;
     private final ReviewMemberRepository reviewMemberRepository;
+    private final ReviewRepository reviewRepository;
+    private final MemberRepository memberRepository;
 
-
-public Long createReviewMember(Review review, Member member, int i) {
-
+public Long createReviewMember(Long review_id, Long member_id, int i) {
+    System.out.println(member_id);
+    Member member = memberRepository.findById(member_id).orElseThrow(NoSuchMemberException::new);
+    Review review = reviewRepository.findById(review_id).orElseThrow(NoSuchReviewException::new);
     Review_Member review_member = Review_Member.createReview_Member(review, member, i);
 
     if (review.getWriter().getId().equals(member.getId())) {

--- a/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
@@ -21,37 +21,25 @@ public class ReviewMemberService {
     private final ReviewMemberRepository reviewMemberRepository;
 
 
-public void createReviewMember(Review review, Member member, int i) {
+public Long createReviewMember(Review review, Member member, int i) {
 
-        if (reviewMemberRepository.findByReview_idAndMember_id(review.getReview_id(), member.getId()).size()!=0) {
-            throw new AlreadyParticipateException("이미 평가한 리뷰입니다");
-        }
-        if (review.getWriter().getId().equals(member.getId())) {
-            throw new CannotRecommendMyReviewException("자신의 리뷰는 추천할 수 없습니다");
-        }
-        reviewMemberRepository.save(Review_Member.createReview_Member(review, member,i));
+    Review_Member review_member = Review_Member.createReview_Member(review, member, i);
+
+    if (review.getWriter().getId().equals(member.getId())) {
+        throw new CannotRecommendMyReviewException("자신의 리뷰는 추천할 수 없습니다");
+    }
+    if (review.getParticipants().contains(review_member)) {
+        throw new AlreadyParticipateException("이미 평가한 리뷰입니다");
+    }
+
+    Review_Member save = reviewMemberRepository.save(review_member);
+    review.getParticipants().add(save);
+    return save.getReview_member_id();
 
 }
 
     public List<Review_Member> findByReviewAndMember(Review review,Member member) {
         return reviewMemberRepository.findByReview_idAndMember_id(review.getReview_id(), member.getId());
     }
-
-    public Long create(Review review, Member member, int i) {
-        Review_Member review_member = Review_Member.createReview_Member(review, member, i);
-
-        if (review.getWriter().getId().equals(member.getId())) {
-            throw new CannotRecommendMyReviewException("자신의 리뷰는 추천할 수 없습니다");
-        }
-        if (review.getParticipants().contains(review_member)) {
-            throw new AlreadyParticipateException("이미 평가한 리뷰입니다");
-        }
-        Review_Member save = reviewMemberRepository.save(review_member);
-        review.getParticipants().add(save);
-        return save.getReview_member_id();
-
-    }
-
-
 
 }

--- a/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
@@ -41,5 +41,8 @@ public Long createReviewMember(Review review, Member member, int i) {
     public List<Review_Member> findByReviewAndMember(Review review,Member member) {
         return reviewMemberRepository.findByReview_idAndMember_id(review.getReview_id(), member.getId());
     }
+    public List<Review_Member> getAll() {
+        return reviewMemberRepository.findAll();
+    }
 
 }

--- a/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
+++ b/src/main/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberService.java
@@ -1,6 +1,7 @@
 package com.Hanium.CarCamping.service.Review_Member;
 
 import com.Hanium.CarCamping.Exception.AlreadyParticipateException;
+import com.Hanium.CarCamping.Exception.CannotRecommendMyReviewException;
 import com.Hanium.CarCamping.domain.entity.Review;
 import com.Hanium.CarCamping.domain.entity.Review_Member;
 import com.Hanium.CarCamping.domain.entity.member.Member;
@@ -22,18 +23,34 @@ public class ReviewMemberService {
 
 public void createReviewMember(Review review, Member member, int i) {
 
-        if (reviewMemberRepository.findByReview_idAndMember_id(review.getReview_id(), member.getId()).size()==0) {
-            reviewMemberRepository.save(Review_Member.createReview_Member(review, member,i));
-        } else {
-            throw new AlreadyParticipateException();
+        if (reviewMemberRepository.findByReview_idAndMember_id(review.getReview_id(), member.getId()).size()!=0) {
+            throw new AlreadyParticipateException("이미 평가한 리뷰입니다");
         }
-    }
+        if (review.getWriter().getId().equals(member.getId())) {
+            throw new CannotRecommendMyReviewException("자신의 리뷰는 추천할 수 없습니다");
+        }
+        reviewMemberRepository.save(Review_Member.createReview_Member(review, member,i));
+
+}
 
     public List<Review_Member> findByReviewAndMember(Review review,Member member) {
         return reviewMemberRepository.findByReview_idAndMember_id(review.getReview_id(), member.getId());
     }
 
+    public Long create(Review review, Member member, int i) {
+        Review_Member review_member = Review_Member.createReview_Member(review, member, i);
+        System.out.println(review.getParticipants().contains(review_member));
+        if (review.getWriter().getId().equals(member.getId())) {
+            throw new CannotRecommendMyReviewException("자신의 리뷰는 추천할 수 없습니다");
+        }
+        if (review.getParticipants().contains(review_member)) {
+            throw new AlreadyParticipateException("이미 평가한 리뷰입니다");
+        }
+        review.getParticipants().add(review_member);
+        Review_Member save = reviewMemberRepository.save(review_member);
+        return save.getReview_member_id();
 
+    }
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         show_sql: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: create
     properties:
       hibernate:
         show_sql: true

--- a/src/test/java/com/Hanium/CarCamping/service/CampSite/CampsiteServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/CampSite/CampsiteServiceTest.java
@@ -57,10 +57,13 @@ class CampsiteServiceTest {
         campsiteService.saveCampSite(setUpCampSite("수원시 차박지", 3F),member);
         campsiteService.saveCampSite(setUpCampSite("파주시 차박지", 4F),member);
         //when
-        List<CampSite> byRegion = campsiteService.findByRegion(경기도);
+        List<CampSite> byRegion = campsiteService.getCampSiteByRegionAndScoreDESC(경기도);
         CampSite result1 = campsiteService.findByName("안양시 차박지");
         CampSite result2 = campsiteService.findById(result1.getCampsite_id());
         //then
+        for (CampSite campSite : byRegion) {
+            System.out.println(campSite.getScore());
+        }
         assertThat(result1).isEqualTo(result2);
         assertThat(byRegion.size()).isEqualTo(3);
         assertThat(result1.getCampsite_id()).isEqualTo(result2.getCampsite_id());

--- a/src/test/java/com/Hanium/CarCamping/service/CampSite/CampsiteServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/CampSite/CampsiteServiceTest.java
@@ -50,7 +50,7 @@ class CampsiteServiceTest {
 
     }
     @Test
-    public void 차박지_검색_기능() throws Exception {
+    public void 차박지_검색및_정렬_기능() throws Exception {
         //given
         Member member = setUpMember();
         campsiteService.saveCampSite(setUpCampSite("안양시 차박지", 5F),member);
@@ -129,7 +129,7 @@ class CampsiteServiceTest {
 
     public Member setUpMember() {
         getDto member = memberCreateService.createMember(createDto.builder().
-                email("test@naver.com")
+                email("test1@naver.com")
                 .password("1234")
                 .nickname("test")
                 .point(3)

--- a/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
@@ -1,6 +1,7 @@
 package com.Hanium.CarCamping.service.Review;
 
 import com.Hanium.CarCamping.Exception.NoSuchMemberException;
+import com.Hanium.CarCamping.Exception.NotReviewWriterException;
 import com.Hanium.CarCamping.domain.dto.campsite.CreateCampSiteDto;
 import com.Hanium.CarCamping.domain.dto.member.createDto;
 import com.Hanium.CarCamping.domain.dto.member.getDto;
@@ -121,13 +122,24 @@ class ReviewServiceTest {
         CreateReviewDto reviewDto = setUpReviewDto("좋아요", 5.0f);
         Long review_id = reviewService.saveReview(reviewDto, member1, campsite1);
         //when
-        System.out.println(reviewService.getAllReview().size());
         reviewService.deleteReview(member1.getEmail(),review_id);
-        System.out.println(reviewService.getAllReview().size());
-
 
         //then
         assertThat(reviewService.getAllReview().size()).isEqualTo(0);
+
+    }
+    @Test
+    public void 리뷰작성자가_아닐때_테스트() throws Exception {
+        Member member1 = memberRepository.findByNickname("차박러1").orElseThrow(NoSuchMemberException::new);
+        Member member2 = memberRepository.findByNickname("차박러2").orElseThrow(NoSuchMemberException::new);
+        CampSite campsite1 = campsiteService.findByName("안양시 차박지");
+        CreateReviewDto reviewDto = setUpReviewDto("좋아요", 5.0f);
+        Long review_id = reviewService.saveReview(reviewDto, member1, campsite1);
+        //when
+        NotReviewWriterException e = assertThrows(NotReviewWriterException.class, () -> reviewService.deleteReview(member2.getEmail(), review_id));
+
+        //then
+        assertThat(e.getMessage()).isEqualTo("리뷰 작성자가 아닙니다");
 
     }
 

--- a/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
@@ -183,7 +183,7 @@ class ReviewServiceTest {
         reviewMemberService.createReviewMember(review4,member4,1);
 
 
-        List<Review> reviews = reviewService.mostRecommendedTop3Review(campsite1);
+        List<Review> reviews = reviewService.mostRecommendedTop3Review(campsite1.getCampsite_id());
         //then
         assertThat(reviews.get(0).getRecommend()).isEqualTo(3);
         assertThat(reviews.get(1).getRecommend()).isEqualTo(2);

--- a/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
@@ -55,8 +55,8 @@ class ReviewServiceTest {
         CreateReviewDto reviewDto1 = setUpReviewDto("싫어요", 1.0f);
 
         //when
-        reviewService.saveReview(reviewDto,member1,campsite1);
-        reviewService.saveReview(reviewDto1,member2,campsite1);
+        reviewService.saveReview(reviewDto,member1.getId(), campsite1.getCampsite_id());
+        reviewService.saveReview(reviewDto1,member1.getId(), campsite1.getCampsite_id());
 
         //then
         List<Review> result = reviewService.getCampSiteReviewByScoreASC(campsite1.getCampsite_id());
@@ -77,9 +77,9 @@ class ReviewServiceTest {
         CreateReviewDto reviewDto2 = setUpReviewDto("싫어요", 1.0f);
 
         //when
-        reviewService.saveReview(reviewDto,member1,campsite1);
-        reviewService.saveReview(reviewDto1,member2,campsite1);
-        reviewService.saveReview(reviewDto2,member2,campsite1);
+        reviewService.saveReview(reviewDto,member1.getId(), campsite1.getCampsite_id());
+        reviewService.saveReview(reviewDto1,member1.getId(), campsite1.getCampsite_id());
+        reviewService.saveReview(reviewDto2,member1.getId(), campsite1.getCampsite_id());
 
         //then
         List<Review> campSiteReviewByScoreDESC = reviewService.getCampSiteReviewByScoreDESC(campsite1.getCampsite_id());
@@ -101,9 +101,9 @@ class ReviewServiceTest {
         CreateReviewDto reviewDto2 = setUpReviewDto("괜찮아요", 2.5f);
 
         //when
-        Long review_id = reviewService.saveReview(reviewDto, member1, campsite1);
-        reviewService.saveReview(reviewDto1,member2,campsite1);
-        reviewService.saveReview(reviewDto2,member2,campsite1);
+        Long review_id = reviewService.saveReview(reviewDto, member1.getId(), campsite1.getCampsite_id());
+        reviewService.saveReview(reviewDto1,member1.getId(), campsite1.getCampsite_id());
+        reviewService.saveReview(reviewDto2,member1.getId(), campsite1.getCampsite_id());
 
         //then
         List<Review> campSiteReviewByDateASC = reviewService.getCampSiteReviewByDateASC(campsite1.getCampsite_id());
@@ -124,7 +124,7 @@ class ReviewServiceTest {
         Member member2 = memberRepository.findByNickname("차박러2").orElseThrow(NoSuchMemberException::new);
         CampSite campsite1 = campsiteService.findByName("안양시 차박지");
         CreateReviewDto reviewDto = setUpReviewDto("좋아요", 5.0f);
-        Long review_id = reviewService.saveReview(reviewDto, member1, campsite1);
+        Long review_id = reviewService.saveReview(reviewDto, member1.getId(), campsite1.getCampsite_id());
         //when
         reviewService.deleteReview(member1.getEmail(),review_id);
 
@@ -138,7 +138,7 @@ class ReviewServiceTest {
         Member member2 = memberRepository.findByNickname("차박러2").orElseThrow(NoSuchMemberException::new);
         CampSite campsite1 = campsiteService.findByName("안양시 차박지");
         CreateReviewDto reviewDto = setUpReviewDto("좋아요", 5.0f);
-        Long review_id = reviewService.saveReview(reviewDto, member1, campsite1);
+        Long review_id = reviewService.saveReview(reviewDto, member1.getId(), campsite1.getCampsite_id());
         //when
         NotReviewWriterException e = assertThrows(NotReviewWriterException.class, () -> reviewService.deleteReview(member2.getEmail(), review_id));
 
@@ -160,10 +160,10 @@ class ReviewServiceTest {
         CreateReviewDto reviewDto2 = setUpReviewDto("중간이야", 3.0f);
         CreateReviewDto reviewDto3 = setUpReviewDto("괜찮아요", 4.0f);
 
-        Long review_id1 = reviewService.saveReview(reviewDto, member1, campsite1);
-        Long review_id2 = reviewService.saveReview(reviewDto1, member1, campsite1);
-        Long review_id3 = reviewService.saveReview(reviewDto2, member1, campsite1);
-        Long review_id4 = reviewService.saveReview(reviewDto3, member1, campsite1);
+        Long review_id1 = reviewService.saveReview(reviewDto, member1.getId(), campsite1.getCampsite_id());
+        Long review_id2 = reviewService.saveReview(reviewDto1, member1.getId(), campsite1.getCampsite_id());
+        Long review_id3 = reviewService.saveReview(reviewDto2, member1.getId(), campsite1.getCampsite_id());
+        Long review_id4 = reviewService.saveReview(reviewDto3, member1.getId(), campsite1.getCampsite_id());
 
         Review review1 = reviewRepository.getById(review_id1);
         Review review2 = reviewRepository.getById(review_id2);

--- a/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review/ReviewServiceTest.java
@@ -112,7 +112,24 @@ class ReviewServiceTest {
             System.out.println(review1);
         }
     }
+    @Test
+    public void 리뷰삭제_테스트() throws Exception {
+        //given
+        Member member1 = memberRepository.findByNickname("차박러1").orElseThrow(NoSuchMemberException::new);
+        Member member2 = memberRepository.findByNickname("차박러2").orElseThrow(NoSuchMemberException::new);
+        CampSite campsite1 = campsiteService.findByName("안양시 차박지");
+        CreateReviewDto reviewDto = setUpReviewDto("좋아요", 5.0f);
+        Long review_id = reviewService.saveReview(reviewDto, member1, campsite1);
+        //when
+        System.out.println(reviewService.getAllReview().size());
+        reviewService.deleteReview(member1.getEmail(),review_id);
+        System.out.println(reviewService.getAllReview().size());
 
+
+        //then
+        assertThat(reviewService.getAllReview().size()).isEqualTo(0);
+
+    }
 
 
 

--- a/src/test/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberServiceTest.java
@@ -87,23 +87,10 @@ class ReviewMemberServiceTest {
         //when
 
         Long aLong = reviewMemberService.create(reviewList.get(0), m2, 1);
-
-        Long aLong1 = reviewMemberService.create(reviewList.get(0), m2, 1);
-        Review_Member byId = reviewMemberRepository.findById(aLong).orElseThrow();
-        Review_Member byId1 = reviewMemberRepository.findById(aLong1).orElseThrow();
-        System.out.println(byId.getReview_member_id());
-        System.out.println(byId.getMember_id());
-        System.out.println(byId.getReview_id());
-        System.out.println(byId1.getReview_member_id());
-        System.out.println(byId1.getMember_id());
-        System.out.println(byId1.getReview_id());
-        System.out.println(byId.hashCode());
-        System.out.println(byId1.hashCode());
-
-        //AlreadyParticipateException e = assertThrows(AlreadyParticipateException.class, () ->reviewMemberService.create(reviewList.get(0),m2,1));
+        AlreadyParticipateException e = assertThrows(AlreadyParticipateException.class, () ->reviewMemberService.create(reviewList.get(0),m2,1));
 
         //then
-        //assertThat(e.getMessage()).isEqualTo("이미 평가한 리뷰입니다");
+        assertThat(e.getMessage()).isEqualTo("이미 평가한 리뷰입니다");
     }
     @Test
     public void 나의리뷰일때() throws Exception {

--- a/src/test/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberServiceTest.java
@@ -54,7 +54,7 @@ class ReviewMemberServiceTest {
         List<Review> reviewList = reviewService.findByCampSite(campsite.getCampsite_id());
 
         //when
-        reviewMemberService.create(reviewList.get(0),m2,1);
+        reviewMemberService.createReviewMember(reviewList.get(0),m2,1);
 
         //then
         assertThat(reviewMemberService.findByReviewAndMember(reviewList.get(0),m2).get(0).getMember_id()).isEqualTo(m2);
@@ -69,7 +69,7 @@ class ReviewMemberServiceTest {
         List<Review> reviewList = reviewService.findByCampSite(campsite.getCampsite_id());
 
         //when
-        reviewMemberService.create(reviewList.get(0),m2,-1);
+        reviewMemberService.createReviewMember(reviewList.get(0),m2,-1);
 
 
         //then
@@ -86,8 +86,8 @@ class ReviewMemberServiceTest {
 
         //when
 
-        Long aLong = reviewMemberService.create(reviewList.get(0), m2, 1);
-        AlreadyParticipateException e = assertThrows(AlreadyParticipateException.class, () ->reviewMemberService.create(reviewList.get(0),m2,1));
+        Long aLong = reviewMemberService.createReviewMember(reviewList.get(0), m2, 1);
+        AlreadyParticipateException e = assertThrows(AlreadyParticipateException.class, () ->reviewMemberService.createReviewMember(reviewList.get(0),m2,1));
 
         //then
         assertThat(e.getMessage()).isEqualTo("이미 평가한 리뷰입니다");
@@ -99,7 +99,7 @@ class ReviewMemberServiceTest {
         List<Review> reviewList = reviewService.findByCampSite(campsite.getCampsite_id());
 
         //when
-        CannotRecommendMyReviewException e = assertThrows(CannotRecommendMyReviewException.class, () -> reviewMemberService.create(reviewList.get(0), m1, 1));
+        CannotRecommendMyReviewException e = assertThrows(CannotRecommendMyReviewException.class, () -> reviewMemberService.createReviewMember(reviewList.get(0), m1, 1));
 
         //then
         assertThat(e.getMessage()).isEqualTo("자신의 리뷰는 추천할 수 없습니다");

--- a/src/test/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberServiceTest.java
+++ b/src/test/java/com/Hanium/CarCamping/service/Review_Member/ReviewMemberServiceTest.java
@@ -105,14 +105,32 @@ class ReviewMemberServiceTest {
         assertThat(e.getMessage()).isEqualTo("자신의 리뷰는 추천할 수 없습니다");
     }
     @Test
-    public void 고아객체삭제_테스트() throws Exception {
+    public void 고아객체_리뷰삭제될때() throws Exception {
         //given
-
-
+        Member m2 = memberRepository.findByNickname("차박러2").orElseThrow(NoSuchMemberException::new);
+        CampSite campsite = campsiteService.findByName("안양시 차박지");
+        List<Review> reviewList = reviewService.findByCampSite(campsite.getCampsite_id());
         //when
-
-
+        reviewMemberService.createReviewMember(reviewList.get(0),m2,1);
+        reviewService.deleteReview(reviewList.get(0).getWriter().getEmail(),reviewList.get(0).getReview_id());
         //then
+        assertThat(reviewMemberService.getAll().size()).isEqualTo(0);
+
+    }
+    @Test
+    public void 고아객체_차박지삭제될때() throws Exception {
+        //given
+        Member m1 = memberRepository.findByNickname("차박러1").orElseThrow(NoSuchMemberException::new);
+        Member m2 = memberRepository.findByNickname("차박러2").orElseThrow(NoSuchMemberException::new);
+        CampSite campsite = campsiteService.findByName("안양시 차박지");
+        List<Review> reviewList = reviewService.findByCampSite(campsite.getCampsite_id());
+        //when
+        reviewMemberService.createReviewMember(reviewList.get(0),m2,1);
+        campsiteService.deleteCampSite(m1.getId(),campsite.getCampsite_id());
+        //then
+        assertThat(reviewService.getAllReview().size()).isEqualTo(0);
+        assertThat(campsiteService.getAllCampSiteList().size()).isEqualTo(0);
+        assertThat(reviewMemberService.getAll().size()).isEqualTo(0);
 
     }
 


### PR DESCRIPTION
Campsite,Member cascade 옵션 제거

리뷰멤버에 36번째줄 participant.add(this) 를 Review_MembrService의 createReviewMember에 옮김.


set자료형 활용을 위해 equals,hashcode 메서드 오버라이딩

CampSite Controller 수정
getLocationCampSiteListByGrade
findByRegion->getCampSiteByRegionAndScoreDESC

Member에 연관관계 추가
point 엔티티 추가
signInDto No
CreateCampSiteDto Builder 삭제, NoArgs 추가

CampSite Controller 
getByName Post->Get
getLocationCampSiteListByGrade location->Region.valueOf(location)

campSiteService
findById 에서 getById->findById(lazy때문에)
(더있었는데 실수로 기입 못함 ㅠ)
Exception Handler로 예외 처리 통일
